### PR TITLE
fix #1176 Pan and Zoom issue with segmentation on image with non-square pixels

### DIFF
--- a/src/eventListeners/internals/renderSegmentationFill.js
+++ b/src/eventListeners/internals/renderSegmentationFill.js
@@ -122,10 +122,7 @@ export function renderFill(evt, labelmapCanvas, isActiveLabelMap) {
 
   transformCanvasContext(context, canvas, viewport);
 
-  const canvasViewportTranslation = {
-    x: viewport.translation.x * viewport.scale,
-    y: viewport.translation.y * viewport.scale,
-  };
+  const canvasViewportTranslation = getCanvasViewportTranslation(eventData);
 
   context.drawImage(
     labelmapCanvas,
@@ -141,4 +138,29 @@ export function renderFill(evt, labelmapCanvas, isActiveLabelMap) {
   context.imageSmoothingEnabled = previousImageSmoothingEnabled;
 
   resetCanvasContextTransform(context);
+}
+
+/**
+ * GetCanvasViewportTranslation - Returns translation coordinations for
+ * canvas viewport with calculation of image row/column pixel spacing.
+ *
+ * @param  {Object} eventData The data associated with the event.
+ * @returns  {Object} The coordinates of the translation.
+ */
+function getCanvasViewportTranslation(eventData) {
+  const { viewport, image } = eventData;
+
+  let widthScale = viewport.scale;
+  let heightScale = viewport.scale;
+
+  if (image.rowPixelSpacing < image.columnPixelSpacing) {
+    widthScale *= image.columnPixelSpacing / image.rowPixelSpacing;
+  } else if (image.columnPixelSpacing < image.rowPixelSpacing) {
+    heightScale *= image.rowPixelSpacing / image.columnPixelSpacing;
+  }
+
+  return {
+    x: viewport.translation.x * widthScale,
+    y: viewport.translation.y * heightScale,
+  };
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix0

* **What is the current behavior?** (You can also link to an open issue here)

#1176


* **What is the new behavior (if this is a feature change)?**

The segmentation boundary and semi-transparent infill undergo the same same translation, providing an accurate view of which pixels have been highlighted.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
